### PR TITLE
重构

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git clone https://github.com/Zhalslar/astrbot_plugin_buttons
 
 打开"data\plugin_data\astrbot_plugin_buttons\buttons_data.json", 按照模板添加按钮数据，键名为按钮名称，键值为按钮内容，键名会被注册成命令来触发这个按钮。
 
-### 外部插件插件调用示例
+### 外部插件调用示例
 
 ```bash
 class MyPlugin(Star):

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ _✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 发按钮插件 ✨_
 
 ## 🤝 介绍
 
-本插件利用napcat进行发包，实现了让野生bot发送QQ按钮，同时为其他astrbot插件提供易用的发按钮接口。
-支持的QQ版本：9.1.55~最新版（已知9.1.75不支持，可以往前回退或往后更新）
+本插件利用napcat进行发包，实现了让野生bot发送QQ按钮(QQ 9.1.55以上可见)，同时为其他astrbot插件提供易用的发按钮接口。
 
 > **warning**:  
 > 发送按钮被检测时容易被封号，请谨慎使用。<br>
@@ -33,76 +32,79 @@ _✨ [astrbot](https://github.com/AstrBotDevs/AstrBot) 发按钮插件 ✨_
 cd /AstrBot/data/plugins
 git clone https://github.com/Zhalslar/astrbot_plugin_buttons
 
-# 控制台重启AstrBot!
-
+# 控制台重启AstrBot
 ```
 
 ## ⌨️ 使用说明
 
 ### 指令调用
 
-发回调按钮（用短杠线）：按钮标签-回调文本
+打开"data\plugin_data\astrbot_plugin_buttons\buttons_data.json", 按照模板添加按钮数据，键名为按钮名称，键值为按钮内容，键名会被注册成命令来触发这个按钮。
 
-```plaintext
-/按钮 点我-我是笨蛋
-```
-
-发链接按钮（用波浪线）：按钮标签~链接
-
-```plaintext
-/按钮 B站~https://www.bilibili.com/
-```
-
-多个按钮请用逗号隔开（中文逗号和英文逗号都可以）
-
-```plaintext
-/按钮 点我-我是笨蛋，彩蛋-我是小南娘，B站~https://www.bilibili.com
-```
-
-多行按钮请用|隔开
-
-```plaintext
-/按钮 点我-我是笨蛋|彩蛋-我是小南娘，B站~https://www.bilibili.com
-```
-
-### 其他插件调用示例
+### 外部插件插件调用示例
 
 ```bash
 class MyPlugin(Star):
     def __init__(self, context: Context):
         super().__init__(context)
 
-    @filter.command("发送按钮")
-    async send_buttons(self, event: AstrMessageEvent):
-        """发送按钮"""
-        buttons = {
-            "type": "button",
-            "content": [
+    @filter.command("点歌")
+    async song(self, event: AstrMessageEvent):
+        """发送按钮进行选歌"""
+        keyboard = [
                 [
-                    {"label": "点我", "callback": "我是笨蛋"},
-                    {"label": "点他", "callback": "我是小男娘"},
+                    {
+                        "label": "第1行",            # 按钮文字
+                        "callback": "第1行第1个按钮", # 命令型按钮
+                        "light": True,              # 是否高亮按钮（默认根据配置选）
+                        "only_admin": True,         # 仅管理员可操作（默认 False）
+                        "allow_users": [123],       # 指定用户可操作（仅only_admin为False时生效）
+                        "allow_roles": [456],       # 指定身份组（仅频道可用）
+                        "enter": True,              # 点击是否直接发送（默认 True）
+                        "reply": False              # 是否引用回复（默认 False）
+                    },
+                    {
+                        "label": "第1行",
+                        "callback": "第1行第2个按钮"
+                    }
                 ],
                 [
-                    {"label": "点她", "callback": "看看腿"},
-                    {"label": "B站", "link": "https://www.bilibili.com"},
-                ],
-            ],
-        }
-        yield event.plain_result(f"{buttons}")
+                    {
+                        "label": "第2行",
+                        "link": "https://example.com"
+                    }
+                ]
+            ]
+        await self.send_button(event, keyboard)
+
+
+     async def send_button(
+        self, event: AiocqhttpMessageEvent, keyboard: list[list[dict[str, str]]]
+    ) -> str | None:
+        """调用buttons插件发送按钮"""
+        button_plugin = self.context.get_registered_star("astrbot_plugin_buttons")
+        if button_plugin.activated:
+            cls = button_plugin.star_cls
+            await cls.send_button(  # type: ignore
+                client=event.bot,
+                keyboard=keyboard,
+                group_id=event.get_group_id(),
+                user_id=event.get_sender_id(),
+            )
+        else:
+            await event.send(
+                event.plain_result(
+                    "astrbot_plugin_buttons插件未激活，无法调用按钮发送服务"
+                )
+            )
+            return
 ```
 
-astrbot_plugin_buttons插件会在消息发送前，自动将消息中的按钮字典buttons转化成按钮数据包来发送
+astrbot_plugin_buttons插件会在消息发送前，自动将消息中的按钮字典buttons转化成字典来发送
 
 ### 示例图
 
-![6de3babc31643ab4c0469fa3c6997f5](https://github.com/user-attachments/assets/3642866f-8686-4d6f-8a1d-0bc073869a00)
 
-
-## 🤝 TODO
-
-- [x] 支持发回调按钮
-- [x] 支持发链接按钮
-- [x] 为其他插件提供发按钮服务
 
 ## 👥 贡献指南
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,18 +1,41 @@
 {
-    "button_style": {
-        "description": "按钮样式",
+    "default_style": {
+        "description": "默认按钮样式",
         "type": "string",
         "options": [
-            "0.全部不加深",
-            "1.全部加深",
-            "2.随机加深",
-            "3.链接加深"
+            "1.全部不加深",
+            "2.全部加深",
+            "3.随机加深",
+            "4.链接加深",
+            "5.间隔加深"
         ],
-        "default": "全部加深"
+        "default": "5.间隔加深"
     },
-    "default_button_input": {
-        "description": "默认按钮",
-        "type": "string",
-        "default": "插件-plugin, 文转图-t2i, 文转音-tts|函数工具-tool ls, 人格-persona list, LLM-llm|服务商-provider, 模型-model|对话列表-ls, 对话记录-history, 重置会话-reset"
+    "default_only_admin": {
+        "description": "仅管理员可点击按钮",
+        "type": "bool",
+        "default": false
+    },
+    "default_allow_users": {
+        "description": "允许点击按钮的用户 ID 列表",
+        "hint": "仅在 '仅管理员可点击按钮' 关闭时生效",
+        "type": "list",
+        "default": []
+    },
+    "default_allow_roles": {
+        "description": "允许点击按钮的身份组 ID 列表",
+        "hint": "频道专用，仅在 '仅管理员可点击按钮' 关闭时生效",
+        "type": "list",
+        "default": []
+    },
+    "default_enter": {
+        "description": "点击按钮后直接发送内容",
+        "type": "bool",
+        "default": true
+    },
+    "default_reply": {
+        "description": "点击按钮后引用原消息回复",
+        "type": "bool",
+        "default": false
     }
 }

--- a/core/button.py
+++ b/core/button.py
@@ -1,0 +1,191 @@
+import uuid
+import random
+from .packet_utils import process_json
+from .protobuf import Protobuf
+
+
+class ButtonBuilder:
+    def __init__(self, config):
+        # 解析按钮样式代码（例如 "5.间隔加深" => "5"）
+        self.default_style_code: str = (
+            config.get("default_style", "1.全部不加深").split(".", 1)[0].strip()
+        )
+        # 是否仅管理员可点击按钮
+        self.default_only_admin: bool = config.get("default_only_admin", False)
+
+        # 默认允许操作的用户 ID 列表（仅在 only_admin 为 False 时生效）
+        self.default_allow_users: list[int] = config.get("default_allow_users", [])
+
+        # 默认允许的身份组（频道专用, 仅在 only_admin 为 False 时生效）
+        self.default_allow_roles: list[int] = config.get("default_allow_roles", [])
+
+        # 默认是否点击即发送
+        self.default_enter: bool = config.get("default_enter", True)
+
+        # 默认是否引用回复原消息
+        self.default_reply: bool = config.get("default_reply", False)
+
+    def build(
+        self,
+        keyboard: list[list[dict]],
+        group_id: int | None,
+        user_id: int | None,
+    ) -> str:
+        buttons_data = self._make_buttons_data(keyboard)
+        button_payload = self._build_button_payload(buttons_data)
+
+        if group_id:
+            target_type = "2"
+            target_id = group_id
+        elif user_id:
+            target_type = "1"
+            target_id = user_id
+        else:
+            raise ValueError("群ID和用户ID不能同时为 None")
+
+        packet = {
+            "1": {target_type: {"1": target_id}},
+            "2": {"1": 1, "2": 0, "3": 0},
+            "3": {"1": {"2": [button_payload]}},
+            "4": random.getrandbits(32),
+            "5": random.getrandbits(32),
+        }
+        return Protobuf.encode(process_json(packet)).hex()
+
+    def _make_buttons_data(self, keyboard: list[list[dict]]) -> list[list[dict]]:
+        result = []
+        for row_idx, row in enumerate(keyboard):
+            rendered_row = []
+            for col_idx, info in enumerate(row):
+                btn = self._build_button(info, row_idx, col_idx)
+                if btn:
+                    rendered_row.append(btn)
+            result.append(rendered_row)
+        return result
+
+    def _build_button(self, info: dict, row: int, col: int) -> dict:
+        label = info.get("label", "").strip()
+        if not label:
+            return {}
+
+        visited_label = info.get("visited_label", f"{label}✔")
+        btn_id = info.get("id", str(uuid.uuid4()))
+        appid = info.get("appid", 102089849)
+        light = info.get("light", None)
+        if light is not None:
+            style = 1 if light else 0
+        else:
+            style = self._select_style("link" in info, row, col)
+
+
+        # 自定义 render_data 覆盖默认值
+        render_data = {
+            "label": label,
+            "visited_label": visited_label,
+            "style": style,
+            **info.get("extra_render", {}),
+        }
+
+        # 构建 action
+        if "link" in info:
+            action_type = 0
+            action_data = info["link"]
+        elif "callback" in info:
+            action_type = 2
+            action_data = info["callback"]
+        else:
+            return {}
+
+        # 权限处理：扁平字段转结构化 permission
+        if info.get("only_admin") or self.default_only_admin:
+            permission = {"type": 1}
+        elif "allow_users" in info or self.default_allow_users:
+            uids = info.get("allow_users") or self.default_allow_users
+            permission = {
+                "type": 0,
+                "specify_user_ids": [str(uid) for uid in uids],
+            }
+        elif "allow_roles" in info or self.default_allow_roles:
+            uids = info.get("allow_roles") or self.default_allow_roles
+            permission = {
+                "type": 3,
+                "specify_role_ids": [str(rid) for rid in uids],
+            }
+        else:
+            permission = {"type": 2}
+
+        action = {
+            "type": action_type,
+            "permission": permission,
+            "data": action_data,
+            "enter": info.get("enter", self.default_enter),
+            "reply": info.get("reply", self.default_reply),
+            **info.get("extra_action", {}),
+        }
+
+        return {
+            "id": btn_id,
+            "render_data": render_data,
+            "action": action,
+            "appid": appid,
+        }
+
+    def _select_style(self, link: bool, row: int, col: int) -> int:
+        match self.default_style_code:
+            case "1":
+                return 0
+            case "2":
+                return 1
+            case "3":
+                return random.choice([0, 1])
+            case "4":
+                return 1 if link else 0
+            case "5":
+                return (
+                    1
+                    if (row % 2 == 0 and col % 2 == 1)
+                    or (row % 2 == 1 and col % 2 == 0)
+                    else 0
+                )
+            case _:
+                return 1
+
+    def _build_button_payload(self, buttons_data: list[list[dict]]) -> dict:
+        rows = []
+        for line in buttons_data:
+            row = []
+            for button in line:
+                row.append(
+                    {
+                        "1": button["id"],
+                        "2": {
+                            "1": button["render_data"]["label"],
+                            "2": button["render_data"]["visited_label"],
+                            "3": button["render_data"]["style"],
+                        },
+                        "3": {
+                            "1": button["action"]["type"],
+                            "2": {
+                                "1": button["action"]["permission"]["type"],
+                                "2": button["action"]["permission"].get(
+                                    "specify_role_ids", []
+                                ),
+                                "3": button["action"]["permission"].get(
+                                    "specify_user_ids", []
+                                ),
+                            },
+                            "4": "err",
+                            "5": button["action"]["data"],
+                            "7": 1 if button["action"].get("reply") else 0,
+                            "8": 1 if button["action"].get("enter") else 0,
+                        },
+                    }
+                )
+            rows.append({"1": row})
+        return {
+            "53": {
+                "1": 46,
+                "2": {"1": {"1": rows, "2": "1145140000"}},
+                "3": 1,
+            }
+        }

--- a/core/button.py
+++ b/core/button.py
@@ -57,10 +57,10 @@ class ButtonBuilder:
         for row_idx, row in enumerate(keyboard):
             rendered_row = []
             for col_idx, info in enumerate(row):
-                btn = self._build_button(info, row_idx, col_idx)
-                if btn:
+                if btn := self._build_button(info, row_idx, col_idx):
                     rendered_row.append(btn)
-            result.append(rendered_row)
+            if rendered_row:
+                result.append(rendered_row)
         return result
 
     def _build_button(self, info: dict, row: int, col: int) -> dict:

--- a/core/packet_utils.py
+++ b/core/packet_utils.py
@@ -1,0 +1,28 @@
+def is_hex_string(s: str) -> bool:
+    """判断是否为合法的十六进制字符串"""
+    if len(s) % 2 != 0:
+        return False
+    return all(c in "0123456789abcdefABCDEF" for c in s)
+
+
+def process_json(data, path=None):
+    """递归处理 JSON 中的 hex->xx 字符串"""
+    if path is None:
+        path = []
+
+    if isinstance(data, dict):
+        return {int(k): process_json(v, path + [str(k)]) for k, v in data.items()}
+
+    elif isinstance(data, list):
+        return [process_json(item, path + [str(i + 1)]) for i, item in enumerate(data)]
+
+    elif isinstance(data, str):
+        if len(path) >= 2 and path[-2:] == ["5", "2"] and is_hex_string(data):
+            return bytes.fromhex(data)
+        if data.startswith("hex->"):
+            hex_part = data[5:]
+            return bytes.fromhex(hex_part) if is_hex_string(hex_part) else data
+        return data
+
+    else:
+        return data

--- a/core/protobuf.py
+++ b/core/protobuf.py
@@ -1,0 +1,70 @@
+class Protobuf:
+    @staticmethod
+    def encode(obj) -> bytes:
+        buffer = bytearray()
+        for tag in sorted(obj.keys()):
+            Protobuf._encode(buffer, tag, obj[tag])
+        return bytes(buffer)
+
+    @staticmethod
+    def _encode(buffer, tag, value):
+        if isinstance(value, list):
+            for item in value:
+                Protobuf._encode_value(buffer, tag, item)
+        else:
+            Protobuf._encode_value(buffer, tag, value)
+
+    @staticmethod
+    def _encode_value(buffer, tag, value):
+        if value is None:
+            return
+        if isinstance(value, int):
+            Protobuf._encode_varint(buffer, tag, value)
+        elif isinstance(value, bool):
+            Protobuf._encode_bool(buffer, tag, value)
+        elif isinstance(value, str):
+            Protobuf._encode_string(buffer, tag, value)
+        elif isinstance(value, (bytes, bytearray)):
+            Protobuf._encode_bytes(buffer, tag, value)
+        elif isinstance(value, dict):
+            nested = Protobuf.encode(value)
+            Protobuf._encode_bytes(buffer, tag, nested)
+        else:
+            raise TypeError(f"Unsupported type {type(value)}")
+
+    @staticmethod
+    def _encode_varint(buffer, tag, value):
+        key = (tag << 3) | 0
+        Protobuf._write_varint(buffer, key)
+        Protobuf._write_varint(buffer, value)
+
+    @staticmethod
+    def _encode_bool(buffer, tag, value):
+        Protobuf._encode_varint(buffer, tag, 1 if value else 0)
+
+    @staticmethod
+    def _encode_string(buffer, tag, value):
+        key = (tag << 3) | 2
+        encoded = value.encode("utf-8")
+        Protobuf._write_varint(buffer, key)
+        Protobuf._write_varint(buffer, len(encoded))
+        buffer.extend(encoded)
+
+    @staticmethod
+    def _encode_bytes(buffer, tag, value):
+        key = (tag << 3) | 2
+        Protobuf._write_varint(buffer, key)
+        Protobuf._write_varint(buffer, len(value))
+        buffer.extend(value)
+
+    @staticmethod
+    def _write_varint(buffer, value):
+        value &= 0xFFFFFFFFFFFFFFFF
+        while True:
+            byte = value & 0x7F
+            value >>= 7
+            if value:
+                buffer.append(byte | 0x80)
+            else:
+                buffer.append(byte)
+                break

--- a/core/storage.py
+++ b/core/storage.py
@@ -18,7 +18,6 @@ class ButtonStorage:
         """
         self.json_path = json_path
         self._storage = self._load_or_create_file(json_path)
-        self._keys_set: set[str] = set(self._storage.keys())
 
     def _load_or_create_file(self, path: str) -> Dict[str, Any]:
         """
@@ -116,7 +115,7 @@ class ButtonStorage:
 
         :return: 当前所有键名集合
         """
-        return self._keys_set
+        return set(self._storage.keys())
 
     def __getitem__(self, name: str) -> Any:
         """

--- a/core/storage.py
+++ b/core/storage.py
@@ -1,0 +1,137 @@
+import json
+from typing import Dict, List, Optional, Any
+
+
+class ButtonStorage:
+    """
+    按钮配置管理类，仅管理键名和对应值的存取，
+    不对值的数据结构做任何约束和处理。
+
+    操作内存数据后会自动同步保存到 JSON 文件。
+    """
+
+    def __init__(self, json_path: str):
+        """
+        初始化并尝试从指定 JSON 文件加载数据，失败时存储为空字典。
+
+        :param json_path: JSON 文件路径
+        """
+        self.json_path = json_path
+        self._storage = self._load_or_create_file(json_path)
+        self._keys_set: set[str] = set(self._storage.keys())
+
+    def _load_or_create_file(self, path: str) -> Dict[str, Any]:
+        """
+        尝试加载 JSON 文件，文件不存在时自动创建空字典文件。
+
+        :param path: JSON 文件路径
+        :return: 文件中加载的字典数据或空字典
+        """
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError("配置文件内容必须是字典")
+            return data
+        except FileNotFoundError:
+            # 文件不存在，创建空字典文件
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({}, f, ensure_ascii=False, indent=2)
+            return {}
+        except (json.JSONDecodeError, ValueError):
+            # 文件内容错误，返回空字典（不覆盖文件）
+            return {}
+
+    def add(self, name: str, value: Any) -> None:
+        """
+        添加或更新指定键及其对应数据，操作后自动保存。
+
+        :param name: 键名
+        :param value: 键对应的任意数据
+        """
+        self._storage[name] = value
+        self.save()
+
+    def get(self, name: str) -> Optional[Any]:
+        """
+        获取指定键对应的数据，找不到返回 None。
+
+        :param name: 键名
+        :return: 键对应数据或 None
+        """
+        return self._storage.get(name)
+
+    def remove(self, name: str) -> bool:
+        """
+        删除指定键及其对应的数据，操作后自动保存。
+
+        :param name: 键名
+        :return: 删除成功返回 True，键不存在返回 False
+        """
+        if name in self._storage:
+            del self._storage[name]
+            self.save()
+            return True
+        return False
+
+    def all(self) -> Dict[str, Any]:
+        """
+        获取所有键值对。
+
+        :return: 当前所有存储的数据字典
+        """
+        return self._storage
+
+    def names(self) -> List[str]:
+        """
+        获取所有键名列表。
+
+        :return: 键名列表
+        """
+        return list(self._storage.keys())
+
+    def get_first(self) -> Optional[Any]:
+        """
+        获取存储中第一个键对应的值，如果为空返回 None。
+        """
+        if not self._storage:
+            return None
+        first_key = next(iter(self._storage))
+        return self._storage[first_key]
+
+    def save(self, path: Optional[str] = None) -> None:
+        """
+        保存当前存储数据到 JSON 文件。
+
+        :param path: 保存路径，默认使用初始化时的文件路径
+        """
+        save_path = path or self.json_path
+        with open(save_path, "w", encoding="utf-8") as f:
+            json.dump(self._storage, f, ensure_ascii=False, indent=2)
+
+    @property
+    def keys_set(self) -> set[str]:
+        """
+        对外公开的键名集合，方便做关键词匹配等。
+
+        :return: 当前所有键名集合
+        """
+        return self._keys_set
+
+    def __getitem__(self, name: str) -> Any:
+        """
+        支持通过 [] 访问数据，键不存在时抛 KeyError。
+
+        :param name: 键名
+        :return: 键对应数据
+        """
+        return self._storage[name]
+
+    def __contains__(self, name: str) -> bool:
+        """
+        判断是否存在指定键。
+
+        :param name: 键名
+        :return: 是否存在
+        """
+        return name in self._storage

--- a/main.py
+++ b/main.py
@@ -1,17 +1,16 @@
-import ast
-import uuid
-import random
-import string
-
+import os
+from typing import Union
 from aiocqhttp import CQHttp
 from astrbot.api.star import Context, Star, register
 from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
 )
-import astrbot.api.message_components as Comp
 from astrbot.api.event import filter
-from .proto import ProtobufEncoder
+from astrbot.core.star.star_tools import StarTools
+from .core.button import ButtonBuilder
+from .core.storage import ButtonStorage
+from astrbot import logger
 
 
 @register(
@@ -24,295 +23,132 @@ from .proto import ProtobufEncoder
 class ButtonPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
-        self.encoder = ProtobufEncoder()
-        self.button_style = config.get("button_style", "1")  # 按钮样式
-        self.default_button_input: str = config.get(
-            "default_button_input", "菜单-help"
-        )  # 默认按钮数据
 
-    @filter.command("按钮", alias={"button"})
-    async def on_command(self, event: AiocqhttpMessageEvent, input: str | None = None):
-        """发按钮，input为按钮数据，格式为：按钮文本-按钮回调/n按钮文本-按钮回调"""
-        # 默认按钮数据
-        if not input:
-            input = self.default_button_input
+        plugin_data_dir = StarTools.get_data_dir("astrbot_plugin_buttons")
+        buttons_data_file = os.path.join(plugin_data_dir, "buttons_data.json")
+        self.storage = ButtonStorage(buttons_data_file)
+        self.builder = ButtonBuilder(config)  # type: ignore
 
-        # 处理输入数据
-        input = input.replace("，", ",")
-        input = input.replace("～", "~")
-
-        # 录入按钮信息
-        buttons_info: list[list[dict]] = []
-
-        for line in input.split("|"):  # 按行分割
-            line_buttons: list[dict] = []
-
-            for element in line.split(","):  # 按逗号分割每行的按钮
-                if "~" in element:  # 链接按钮格式
-                    label, link = element.split("~", 1)
-                    line_buttons.append({"label": label, "link": link})
-                elif "-" in element:  # 回调按钮格式
-                    label, callback = element.split("-", 1)
-                    line_buttons.append({"label": label, "callback": callback})
-                else:
-                    yield event.plain_result(f"无效的按钮格式: {element}")
-                    return
-
-            buttons_info.append(line_buttons)
-            print(buttons_info)
-
-        client = event.bot
-        group_id = event.get_group_id()
-        user_id = event.get_sender_id()
-        await self.send_button(client, buttons_info, group_id, user_id)
-        event.stop_event()
-
-    @filter.on_decorating_result()
-    async def on_decorating_result(self, event: AiocqhttpMessageEvent):
-        """
-        监听消息中的按钮发送事件，并发送按钮，按钮消息结构示例如下（字符串型字典）
-        {
-            "type": "button",
-            "content": [
-                [
-                    {"label": "点我", "callback": "我是笨蛋"},
-                    {"label": "点他", "callback": "我是小男娘"},
-                ],
-                [
-                    {"label": "点她", "callback": "看看腿"},
-                    {"label": "点你", "link": "看看玉足"},
-                ],
-            ],
-        }
-        """
-        chain = event.get_result().chain
-        seg = chain[0]
-        # 仅允许只含有单条文本的消息链通过
-        if not (len(chain) == 1 and isinstance(seg, Comp.Plain)):
-            return
-        # 将字符串转换为字典
-        try:
-            extracted_dict = ast.literal_eval(seg.text)
-        except (ValueError, SyntaxError):
-            return
-        # 检测type键值是否为button
-        if extracted_dict.get("type") != "button":
-            return
-        buttons_info = extracted_dict.get("content", [])
-        client = event.bot
-        group_id = event.get_group_id()
-        user_id = event.get_sender_id()
-        await self.send_button(client, buttons_info, group_id, user_id)
-        chain.clear()  # 清空消息段
-        event.stop_event()
+    @filter.event_message_type(filter.EventMessageType.ALL)
+    async def on_message(self, event: AiocqhttpMessageEvent):
+        """监听消息，触发按钮"""
+        for key in self.storage.keys_set:
+            if key in event.message_str:
+                if keyboard := self.storage.get(key):
+                    await self.send_button(
+                        client=event.bot,
+                        keyboard=keyboard,
+                        group_id=int(event.get_group_id()),
+                        user_id=int(event.get_sender_id()),
+                    )
+                    logger.debug(f"尝试发送的按钮数据：{keyboard}")
+                    event.stop_event()
 
     async def send_button(
         self,
         client: CQHttp,
-        buttons_info: list[list[dict]],
-        group_id: int | str | None,
-        user_id: int | str | None,
-    ) -> str | None:
-        """发按钮，buttons_info为按钮数据"""
+        keyboard: list[list[dict]],
+        group_id: Union[int, str, None] = None,
+        user_id: Union[int, str, None] = None,
+    ) -> None:
+        """
+        通用按钮发送函数（供插件/模块调用，支持 Napcat）。
 
-        # 检查信息格式
-        for line in buttons_info:
-            for button_info in line:
-                # 确保是字典，并且包含 "label" 和 "callback" 或 "link"
-                if (
-                    not isinstance(button_info, dict)
-                    or "label" not in button_info
-                    or ("callback" not in button_info and "link" not in button_info)
-                    or not button_info["label"]
-                    or not (button_info.get("callback") or button_info.get("link"))
-                ):
-                    return "输入格式错误"
+        参数：
+            client: CQHttp 实例
+            keyboard: 二维按钮结构，每行一个列表
+            group_id: 群 ID（优先使用）
+            user_id: 用户 ID（群 ID 不存在时使用）
 
-        # 制作按钮, 将 buttons_info 转化为 buttons_data
-        buttons_data: list[list[dict]] = [
-            [
-                button_data
-                for button_info in line
-                if (button_data := self._make_button(button_info)) is not None
-            ]
-            for line in buttons_info
-        ]
-
-        # 转化按钮数据
-        buttons_data_ = [
-            {
-                "1": [
+        示例：
+            keyboard = [
+                [
                     {
-                        "1": button_data["id"],  # 按钮 ID
-                        "2": {
-                            "1": button_data["render_data"]["label"],  # 按钮文本
-                            "2": button_data["render_data"][
-                                "visited_label"
-                            ],  # 点击后的文本
-                            "3": button_data["render_data"]["style"],  # 按钮样式
-                        },
-                        "3": {
-                            "1": button_data["action"]["type"],  # 按钮类型
-                            "2": {
-                                "1": button_data["action"]["permission"][
-                                    "type"
-                                ],  # 权限类型
-                                "2": button_data["action"]["permission"].get(
-                                    "specify_role_ids", []
-                                ),  # 指定角色 ID
-                                "3": button_data["action"]["permission"].get(
-                                    "specify_user_ids", []
-                                ),  # 指定用户 ID
-                            },
-                            "4": "err",  # 错误信息
-                            "5": button_data["action"]["data"],  # 按钮数据
-                            "7": 1
-                            if button_data["action"].get("reply", False)
-                            else 0,  # 回复行为
-                            "8": 1
-                            if button_data["action"].get("enter", False)
-                            else 0,  # 回车键行为
-                        },
+                        "label": "第1行",            # 按钮文字
+                        "callback": "第1行第1个按钮", # 命令型按钮
+                        "light": True,              # 是否高亮按钮（默认根据配置选）
+                        "only_admin": True,         # 仅管理员可操作（默认 False）
+                        "allow_users": [123],       # 指定用户可操作（仅only_admin为False时生效）
+                        "allow_roles": [456],       # 指定身份组（仅频道可用）
+                        "enter": True,              # 点击是否直接发送（默认 True）
+                        "reply": False              # 是否引用回复（默认 False）
+                    },
+                    {
+                        "label": "第1行",
+                        "callback": "第1行第2个按钮"
                     }
-                    for button_data in lines
+                ],
+                [
+                    {
+                        "label": "第2行",
+                        "link": "https://example.com"
+                    }
                 ]
-            }
-            for lines in buttons_data
-        ]
+            ]
 
-        # 构造按钮数据包
-        button_packet = {
-            "53": {
-                "1": 46,
-                "2": {
-                    "1": {
-                        "1": buttons_data_,
-                        "2": "1145140000",
-                    }
-                },
-                "3": 1,
-            }
-        }
+            await send_button(client, keyboard, group_id=12345678)
+        """
+        if group_id is None and user_id is None:
+            raise ValueError("群ID和用户ID不能同时为 None")
 
-        # 构造数据包
-        packet = {
-            "1": {
-                "2" if group_id else "1": {
-                    "1": int(group_id) if group_id else int(user_id)  # type: ignore
-                }
-            },  # type: ignore
-            "2": {"1": 1, "2": 0, "3": 0},
-            "3": {"1": {"2": [button_packet]}},
-            "4": random.getrandbits(32),  # 需要保证唯一性，每个数据包都应该用不同的值
-            "5": random.getrandbits(32),  # 同上
-        }
+        pb_hex = self.builder.build(
+            keyboard=keyboard,
+            group_id=int(group_id) if group_id else None,
+            user_id=int(user_id) if user_id else None,
+        )
+        await client.api.call_action(
+            "send_packet", cmd="MessageSvc.PbSendMsg", data=pb_hex
+        )
 
-        # 处理JSON数据包
-        processed = self._process_json(packet)
+    async def send_callback_button(
+        self,
+        client: CQHttp,
+        buttons: dict[str, str],
+        group_id: Union[int, str, None] = None,
+        user_id: Union[int, str, None] = None,
+        per_row: int = 3,
+    ) -> None:
+        """
+        快速发送 callback 类型按钮，仅需提供 label → callback 映射。
 
-        # 转为protobuf
-        encoded_data = self.encoder.encode(processed)
+        示例：
+            await send_callback_button(client, {
+                "模型": "model",
+                "插件": "plugin",
+                "重置": "reset"
+            }, group_id=123)
+        """
+        keyboard = self._dict_to_keyboard(buttons, field="callback", per_row=per_row)
+        await self.send_button(client, keyboard, group_id=group_id, user_id=user_id)
 
-        # 转为16进制
-        hex_string = encoded_data.hex()
+    async def send_link_button(
+        self,
+        client: CQHttp,
+        buttons: dict[str, str],
+        group_id: Union[int, str, None] = None,
+        user_id: Union[int, str, None] = None,
+        per_row: int = 3,
+    ) -> None:
+        """
+        快速发送 link 类型按钮，仅需提供 label → URL 映射。
 
-        # 调用napcat的send_packet接口进行发包
-        payload = {"cmd": "MessageSvc.PbSendMsg", "data": hex_string}
-        await client.api.call_action("send_packet", **payload)
-
-    def _make_button(self, button_info: dict) -> dict:
-        """制作按钮"""
-        label = button_info.get("label", "").strip()
-        clicked_text = button_info.get("clicked_text", "").strip()
-        link = button_info.get("link")
-        callback = button_info.get("callback")
-
-        if "0" in self.button_style:
-            button_style = 0
-        elif "1" in self.button_style:
-            button_style = 1
-        elif "2" in self.button_style:
-            button_style = random.choice([0, 1])
-        elif "3" in self.button_style and link:
-            button_style = 1
-        else:
-            button_style = 1
-
-        # 构建基础消息结构
-        button_data = {
-            "id": str(uuid.uuid4()),  # 生成唯一 ID
-            "render_data": {
-                "label": label,  # 按钮文本
-                "visited_label": clicked_text,  # 点击后的文本
-                "style": button_style,  # 按钮样式
-                **button_info.get("QQBot", {}).get(
-                    "render_data", {}
-                ),  # 扩展 QQBot 的 render_data 属性
-            },
-            "appid": 102089849,  # 应用 ID
-        }
-
-        # 根据按钮类型构建 action 属性
-        if link:
-            button_data["action"] = {
-                "type": 0,  # 链接类型
-                "permission": {"type": 2},
-                "data": link,  # 链接地址
-                **button_info.get("QQBot", {}).get(
-                    "action", {}
-                ),  # 扩展 QQBot 的 action 属性
-            }
-        elif callback:
-            button_data["action"] = {
-                "type": 2,  # 回调类型
-                "permission": {"type": 2},
-                "data": callback,  # 回调数据
-                "enter": True,  # 回车键行为
-                **button_info.get("QQBot", {}).get(
-                    "action", {}
-                ),  # 扩展 QQBot 的 action 属性
-            }
-        else:
-            return {}  # 如果既没有链接也没有回调，则返回空字典
-
-        return button_data
+        示例：
+            await send_link_buttons(client, {
+                "官网": "https://example.com",
+                "文档": "https://docs.example.com"
+            }, group_id=123)
+        """
+        keyboard = self._dict_to_keyboard(buttons, field="link", per_row=per_row)
+        await self.send_button(client, keyboard, group_id=group_id, user_id=user_id)
 
     @staticmethod
-    def _is_hex_string(s):
-        """判断是否为16进制字符串"""
-        if len(s) % 2 != 0:
-            return False
-        hex_chars = set(string.hexdigits)
-        return all(c.lower() in hex_chars for c in s)
-
-    def _process_json(self, data, path=None):
-        """处理JSON数据包"""
-        if path is None:
-            path = []
-        if isinstance(data, dict):
-            result = {}
-            for key in data:
-                num_key = int(key)
-                current_path = path + [str(key)]
-                value = data[key]
-                processed_value = self._process_json(value, current_path)
-                result[num_key] = processed_value
-            return result
-        elif isinstance(data, list):
-            return [
-                self._process_json(item, path + [str(i + 1)])
-                for i, item in enumerate(data)
-            ]
-        elif isinstance(data, str):
-            if len(path) >= 2 and path[-2:] == ["5", "2"] and self._is_hex_string(data):
-                return bytes.fromhex(data)
-            if data.startswith("hex->"):
-                hex_part = data[5:]
-                if self._is_hex_string(hex_part):
-                    return bytes.fromhex(hex_part)
-                else:
-                    return data
-            else:
-                return data
-        else:
-            return data
+    def _dict_to_keyboard(
+        mapping: dict[str, str], field: str, per_row: int = 3
+    ) -> list[list[dict]]:
+        """将 {label: value} 字典转换为 keyboard 列表结构"""
+        items = list(mapping.items())
+        keyboard = []
+        for i in range(0, len(items), per_row):
+            row = [{"label": k, field: v} for k, v in items[i : i + per_row]]
+            keyboard.append(row)
+        return keyboard

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from astrbot import logger
     "astrbot_plugin_buttons",
     "Zhalslar",
     "[仅napcat] 让QQ的野生bot也能发送按钮！",
-    "1.0.1",
+    "2.0.0",
     "https://github.com/Zhalslar/astrbot_plugin_buttons",
 )
 class ButtonPlugin(Star):


### PR DESCRIPTION
v2重构，支持更多按钮的自定义属性，优化代码风格，优化外部调用，支持存储按钮数据

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构按钮插件至 Version 2 设计，通过将构建器、存储和 Protobuf 工具提取到专用模块中，添加持久化的 JSON 支持的按钮定义，并提供简化的、高级的 API 用于按钮发送，同时相应地更新文档。

新特性：
- 为按钮定义和匹配消息上的动态触发器添加持久化的 JSON 支持的存储
- 公开高级 API，用于从外部插件发送自定义按钮、仅回调按钮和仅链接按钮
- 引入 ButtonBuilder、Protobuf 和 PacketUtils 模块，以组装和编码具有可自定义属性的按钮数据包

增强功能：
- 通过将构建器逻辑解耦到核心模块并简化消息处理，将插件重构为 v2 架构
- 用存储驱动的事件监听器替换手动命令解析，该监听器自动发送匹配键的按钮
- 泛化 send_button 实现以支持 Napcat 和各种用例

文档：
- 使用基于存储的配置说明和修订后的外部插件使用示例更新 README

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构按钮插件至 v2 设计，通过将核心逻辑模块化到专用模块中，为自定义按钮触发器添加持久的 JSON 后端存储，并公开简化的用于按钮发送的高级 API。更新文档并将版本提升至 2.0.0。

新功能：
- 将按钮定义持久化存储在 JSON 存储中，以支持基于关键词的触发
- 公开用于发送通用按钮、仅回调按钮和仅链接按钮的高级 API 方法

增强功能：
- 通过将 ButtonBuilder、ButtonStorage、Protobuf 和 PacketUtils 提取到专用模块中，将插件重构为 v2 架构
- 用存储驱动的事件监听器替换手动按钮解析，以实现更简洁的消息处理
- 将 send_button 逻辑通用化，使用 ButtonBuilder 进行数据包构建
- 将插件版本提升至 2.0.0

文档：
- 更新 README 以解释基于 JSON 的按钮配置，并演示新的外部 API 用法

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the buttons plugin to a v2 design by modularizing core logic into dedicated modules, adding persistent JSON-backed storage for custom button triggers, and exposing simplified high-level APIs for button sending. Update documentation and bump version to 2.0.0.

New Features:
- Persist button definitions in JSON storage to support keyword-based triggers
- Expose high-level API methods for sending generic, callback-only, and link-only buttons

Enhancements:
- Refactor plugin into v2 architecture by extracting ButtonBuilder, ButtonStorage, Protobuf, and PacketUtils into dedicated modules
- Replace manual button parsing with a storage-driven event listener for cleaner message handling
- Generalize send_button logic to use ButtonBuilder for packet construction
- Bump plugin version to 2.0.0

Documentation:
- Update README to explain JSON-based button configuration and demonstrate the new external API usage

</details>

</details>